### PR TITLE
feat(cli): Improve error messages (Issue #6)

### DIFF
--- a/cli/cmd/execute.go
+++ b/cli/cmd/execute.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/elysium/elysium/cli/internal/emblem"
+	"github.com/elysium/elysium/cli/internal/errfmt"
 	"github.com/elysium/elysium/cli/internal/executor"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
@@ -87,7 +88,12 @@ func executeEmblemAction(emblemName string, args []string) error {
 	cachePath := filepath.Join(home, ".elysium", "cache", fmt.Sprintf("%s@%s", emblemName, installedVersion), "emblem.yaml")
 	def, err := emblem.Load(cachePath)
 	if err != nil {
-		return fmt.Errorf("failed to load emblem: %w", err)
+		if strings.Contains(err.Error(), "YAML") || strings.Contains(err.Error(), "yaml") {
+			return errfmt.InvalidYAMLError(cachePath, err)
+		}
+		return errfmt.NewDetailedError(err).
+			WithContext("Emblem", emblemName).
+			WithContext("Cache path", cachePath)
 	}
 
 	if actionName == "" {
@@ -121,7 +127,29 @@ func executeEmblemAction(emblemName string, args []string) error {
 	exec := executor.New(def)
 	result, err := exec.Execute(actionName, params, outputFormat)
 	if err != nil {
-		return fmt.Errorf("execution failed: %w", err)
+		if strings.Contains(err.Error(), "connection refused") {
+			return errfmt.ConnectionError(def.BaseURL, err)
+		}
+		if strings.Contains(err.Error(), "timeout") {
+			return errfmt.NewDetailedError(err).
+				WithReason("Request timed out").
+				WithContext("Timeout", "30s").
+				WithContext("Emblem", emblemName).
+				WithContext("Action", actionName).
+				WithSuggestion("The API is taking too long to respond. Try again or check API status.")
+		}
+		if strings.Contains(err.Error(), "api key") || strings.Contains(err.Error(), "unauthorized") || strings.Contains(err.Error(), "401") {
+			if def.Auth.KeyEnv != "" {
+				return errfmt.AuthRequiredError(def.Auth.KeyEnv)
+			}
+			return errfmt.AuthRequiredError("API_KEY")
+		}
+		if strings.Contains(err.Error(), "rate limit") || strings.Contains(err.Error(), "429") {
+			return errfmt.RateLimitError(60)
+		}
+		return errfmt.NewDetailedError(err).
+			WithContext("Emblem", emblemName).
+			WithContext("Action", actionName)
 	}
 
 	fmt.Println(string(result))

--- a/cli/cmd/keys_test.go
+++ b/cli/cmd/keys_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -214,8 +215,8 @@ func TestUnauthorizedError(t *testing.T) {
 			t.Fatal("Expected error, got nil")
 		}
 
-		if err.Error() != "API error: Unauthorized" {
-			t.Errorf("Expected 'API error: Unauthorized', got '%s'", err.Error())
+		if !strings.Contains(err.Error(), "authentication required") {
+			t.Errorf("Expected error to contain 'authentication required', got '%s'", err.Error())
 		}
 	})
 }
@@ -237,8 +238,8 @@ func TestNotFoundError(t *testing.T) {
 			t.Fatal("Expected error, got nil")
 		}
 
-		if err.Error() != "API error: Key not found" {
-			t.Errorf("Expected 'API error: Key not found', got '%s'", err.Error())
+		if !strings.Contains(err.Error(), "Key not found") {
+			t.Errorf("Expected error to contain 'Key not found', got '%s'", err.Error())
 		}
 	})
 }

--- a/cli/cmd/login.go
+++ b/cli/cmd/login.go
@@ -8,9 +8,11 @@ import (
 	"net"
 	"net/http"
 	"os/exec"
+	"strings"
 	"time"
 
 	"github.com/elysium/elysium/cli/internal/config"
+	"github.com/elysium/elysium/cli/internal/errfmt"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -107,7 +109,16 @@ func runLogin(cmd *cobra.Command, args []string) error {
 		return nil
 
 	case err := <-errChan:
-		return fmt.Errorf("server error: %w", err)
+		if strings.Contains(err.Error(), "connection refused") || strings.Contains(err.Error(), "connect: connection refused") {
+			return errfmt.ConnectionError(registry, err)
+		}
+		if strings.Contains(err.Error(), "timeout") {
+			return errfmt.NewDetailedError(err).
+				WithReason("Authentication timed out").
+				WithContext("Timeout", "5 minutes").
+				WithSuggestion("Try again or check your network connection")
+		}
+		return errfmt.NetworkError(err)
 
 	case <-timeout.C:
 		return fmt.Errorf("authentication timed out after 5 minutes")

--- a/cli/cmd/pull.go
+++ b/cli/cmd/pull.go
@@ -2,10 +2,12 @@ package cmd
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/elysium/elysium/cli/internal/api"
 	"github.com/elysium/elysium/cli/internal/config"
 	"github.com/elysium/elysium/cli/internal/emblem"
+	"github.com/elysium/elysium/cli/internal/errfmt"
 	"github.com/spf13/cobra"
 )
 
@@ -42,7 +44,18 @@ Examples:
 
 		emblemInfo, err := client.GetEmblem(name)
 		if err != nil {
-			return fmt.Errorf("failed to get emblem: %w", err)
+			if strings.Contains(err.Error(), "not found") {
+				return errfmt.EmblemNotFoundError(name)
+			}
+			if strings.Contains(err.Error(), "connection refused") || strings.Contains(err.Error(), "connect: connection refused") {
+				return errfmt.ConnectionError(cfg.Registry, err)
+			}
+			if strings.Contains(err.Error(), "timeout") {
+				return errfmt.NewDetailedError(err).
+					WithReason("Request timed out").
+					WithSuggestion("Try again or check your network connection")
+			}
+			return errfmt.NetworkError(err)
 		}
 
 		if version == "latest" {
@@ -51,7 +64,14 @@ Examples:
 
 		ver, err := client.GetEmblemVersion(name, version)
 		if err != nil {
-			return fmt.Errorf("failed to get emblem version: %w", err)
+			if strings.Contains(err.Error(), "not found") {
+				return errfmt.NewDetailedError(fmt.Errorf("version '%s' not found for emblem '%s'", version, name)).
+					WithSuggestion(fmt.Sprintf("Try: ely pull %s (to get latest version)", name))
+			}
+			if strings.Contains(err.Error(), "connection refused") {
+				return errfmt.ConnectionError(cfg.Registry, err)
+			}
+			return errfmt.NetworkError(err)
 		}
 
 		if err := emblem.SaveToCache(name, version, []byte(ver.YAMLContent)); err != nil {

--- a/cli/internal/api/client.go
+++ b/cli/internal/api/client.go
@@ -3,9 +3,11 @@ package api
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/elysium/elysium/cli/internal/config"
+	"github.com/elysium/elysium/cli/internal/errfmt"
 	"github.com/go-resty/resty/v2"
 )
 
@@ -106,13 +108,21 @@ func (c *Client) ListEmblems(category string, limit, offset int) ([]Emblem, erro
 
 	resp, err := req.Get(c.baseURL + "/api/emblems")
 	if err != nil {
-		return nil, fmt.Errorf("failed to list emblems: %w", err)
+		if strings.Contains(err.Error(), "connection refused") || strings.Contains(err.Error(), "connect: connection refused") {
+			return nil, errfmt.ConnectionError(c.baseURL, err)
+		}
+		if strings.Contains(err.Error(), "timeout") {
+			return nil, errfmt.NewDetailedError(err).
+				WithReason("Request timed out").
+				WithSuggestion("Try again or check your network connection")
+		}
+		return nil, errfmt.NetworkError(err)
 	}
 
 	if resp.IsError() {
 		var errResp ErrorResponse
 		json.Unmarshal(resp.Body(), &errResp)
-		return nil, fmt.Errorf("API error: %s", errResp.Error)
+		return nil, errfmt.APIError(resp.StatusCode(), errResp.Error)
 	}
 
 	var emblems []Emblem
@@ -140,13 +150,16 @@ func (c *Client) SearchEmblems(query, category, sort string, limit, offset int) 
 
 	resp, err := req.Get(c.baseURL + "/api/emblems/search")
 	if err != nil {
-		return nil, fmt.Errorf("failed to search emblems: %w", err)
+		if strings.Contains(err.Error(), "connection refused") || strings.Contains(err.Error(), "connect: connection refused") {
+			return nil, errfmt.ConnectionError(c.baseURL, err)
+		}
+		return nil, errfmt.NetworkError(err)
 	}
 
 	if resp.IsError() {
 		var errResp ErrorResponse
 		json.Unmarshal(resp.Body(), &errResp)
-		return nil, fmt.Errorf("API error: %s", errResp.Error)
+		return nil, errfmt.APIError(resp.StatusCode(), errResp.Error)
 	}
 
 	var emblems []Emblem
@@ -160,13 +173,19 @@ func (c *Client) SearchEmblems(query, category, sort string, limit, offset int) 
 func (c *Client) GetEmblem(name string) (*Emblem, error) {
 	resp, err := c.client.R().Get(c.baseURL + "/api/emblems/" + name)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get emblem: %w", err)
+		if strings.Contains(err.Error(), "connection refused") || strings.Contains(err.Error(), "connect: connection refused") {
+			return nil, errfmt.ConnectionError(c.baseURL, err)
+		}
+		return nil, errfmt.NetworkError(err)
 	}
 
 	if resp.IsError() {
 		var errResp ErrorResponse
 		json.Unmarshal(resp.Body(), &errResp)
-		return nil, fmt.Errorf("API error: %s", errResp.Error)
+		if resp.StatusCode() == 404 {
+			return nil, errfmt.EmblemNotFoundError(name)
+		}
+		return nil, errfmt.APIError(resp.StatusCode(), errResp.Error)
 	}
 
 	var emblem Emblem
@@ -180,13 +199,20 @@ func (c *Client) GetEmblem(name string) (*Emblem, error) {
 func (c *Client) GetEmblemVersion(name, version string) (*EmblemVersion, error) {
 	resp, err := c.client.R().Get(fmt.Sprintf("%s/api/emblems/%s/%s", c.baseURL, name, version))
 	if err != nil {
-		return nil, fmt.Errorf("failed to get emblem version: %w", err)
+		if strings.Contains(err.Error(), "connection refused") || strings.Contains(err.Error(), "connect: connection refused") {
+			return nil, errfmt.ConnectionError(c.baseURL, err)
+		}
+		return nil, errfmt.NetworkError(err)
 	}
 
 	if resp.IsError() {
 		var errResp ErrorResponse
 		json.Unmarshal(resp.Body(), &errResp)
-		return nil, fmt.Errorf("API error: %s", errResp.Error)
+		if resp.StatusCode() == 404 {
+			return nil, errfmt.NewDetailedError(fmt.Errorf("version '%s' not found for emblem '%s'", version, name)).
+				WithSuggestion(fmt.Sprintf("Try: ely pull %s (to get latest version)", name))
+		}
+		return nil, errfmt.APIError(resp.StatusCode(), errResp.Error)
 	}
 
 	var ver EmblemVersion
@@ -211,13 +237,16 @@ func (c *Client) PublishEmblem(name, description, yamlContent, version string, c
 		SetBody(body).
 		Post(c.baseURL + "/api/emblems")
 	if err != nil {
-		return nil, fmt.Errorf("failed to publish emblem: %w", err)
+		if strings.Contains(err.Error(), "connection refused") || strings.Contains(err.Error(), "connect: connection refused") {
+			return nil, errfmt.ConnectionError(c.baseURL, err)
+		}
+		return nil, errfmt.NetworkError(err)
 	}
 
 	if resp.IsError() {
 		var errResp ErrorResponse
 		json.Unmarshal(resp.Body(), &errResp)
-		return nil, fmt.Errorf("API error: %s", errResp.Error)
+		return nil, errfmt.APIError(resp.StatusCode(), errResp.Error)
 	}
 
 	var emblem Emblem
@@ -231,13 +260,19 @@ func (c *Client) PublishEmblem(name, description, yamlContent, version string, c
 func (c *Client) ListKeys() ([]Key, error) {
 	resp, err := c.client.R().Get(c.baseURL + "/api/keys")
 	if err != nil {
-		return nil, fmt.Errorf("failed to list keys: %w", err)
+		if strings.Contains(err.Error(), "connection refused") || strings.Contains(err.Error(), "connect: connection refused") {
+			return nil, errfmt.ConnectionError(c.baseURL, err)
+		}
+		return nil, errfmt.NetworkError(err)
 	}
 
 	if resp.IsError() {
 		var errResp ErrorResponse
 		json.Unmarshal(resp.Body(), &errResp)
-		return nil, fmt.Errorf("API error: %s", errResp.Error)
+		if resp.StatusCode() == 401 {
+			return nil, errfmt.AuthRequiredError("API_KEY")
+		}
+		return nil, errfmt.APIError(resp.StatusCode(), errResp.Error)
 	}
 
 	var keys []Key
@@ -264,13 +299,19 @@ func (c *Client) CreateKey(name string, expiresAt *time.Time) (*Key, error) {
 		SetBody(body).
 		Post(c.baseURL + "/api/keys")
 	if err != nil {
-		return nil, fmt.Errorf("failed to create key: %w", err)
+		if strings.Contains(err.Error(), "connection refused") || strings.Contains(err.Error(), "connect: connection refused") {
+			return nil, errfmt.ConnectionError(c.baseURL, err)
+		}
+		return nil, errfmt.NetworkError(err)
 	}
 
 	if resp.IsError() {
 		var errResp ErrorResponse
 		json.Unmarshal(resp.Body(), &errResp)
-		return nil, fmt.Errorf("API error: %s", errResp.Error)
+		if resp.StatusCode() == 401 {
+			return nil, errfmt.AuthRequiredError("API_KEY")
+		}
+		return nil, errfmt.APIError(resp.StatusCode(), errResp.Error)
 	}
 
 	var key Key
@@ -284,13 +325,19 @@ func (c *Client) CreateKey(name string, expiresAt *time.Time) (*Key, error) {
 func (c *Client) GetKey(id string) (*Key, error) {
 	resp, err := c.client.R().Get(c.baseURL + "/api/keys/" + id)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get key: %w", err)
+		if strings.Contains(err.Error(), "connection refused") || strings.Contains(err.Error(), "connect: connection refused") {
+			return nil, errfmt.ConnectionError(c.baseURL, err)
+		}
+		return nil, errfmt.NetworkError(err)
 	}
 
 	if resp.IsError() {
 		var errResp ErrorResponse
 		json.Unmarshal(resp.Body(), &errResp)
-		return nil, fmt.Errorf("API error: %s", errResp.Error)
+		if resp.StatusCode() == 401 {
+			return nil, errfmt.AuthRequiredError("API_KEY")
+		}
+		return nil, errfmt.APIError(resp.StatusCode(), errResp.Error)
 	}
 
 	var key Key
@@ -304,13 +351,19 @@ func (c *Client) GetKey(id string) (*Key, error) {
 func (c *Client) DeleteKey(id string) error {
 	resp, err := c.client.R().Delete(c.baseURL + "/api/keys/" + id)
 	if err != nil {
-		return fmt.Errorf("failed to delete key: %w", err)
+		if strings.Contains(err.Error(), "connection refused") || strings.Contains(err.Error(), "connect: connection refused") {
+			return errfmt.ConnectionError(c.baseURL, err)
+		}
+		return errfmt.NetworkError(err)
 	}
 
 	if resp.IsError() {
 		var errResp ErrorResponse
 		json.Unmarshal(resp.Body(), &errResp)
-		return fmt.Errorf("API error: %s", errResp.Error)
+		if resp.StatusCode() == 401 {
+			return errfmt.AuthRequiredError("API_KEY")
+		}
+		return errfmt.APIError(resp.StatusCode(), errResp.Error)
 	}
 
 	return nil

--- a/cli/internal/errfmt/color.go
+++ b/cli/internal/errfmt/color.go
@@ -1,0 +1,30 @@
+package errfmt
+
+import (
+	"os"
+)
+
+var (
+	colorEnabled = true
+)
+
+func init() {
+	if os.Getenv("NO_COLOR") != "" {
+		colorEnabled = false
+	}
+}
+
+const (
+	colorReset  = "\033[0m"
+	colorRed    = "\033[31m"
+	colorYellow = "\033[33m"
+	colorCyan   = "\033[36m"
+	colorGray   = "\033[90m"
+)
+
+func colorize(text, color string) string {
+	if !colorEnabled {
+		return text
+	}
+	return color + text + colorReset
+}

--- a/cli/internal/errfmt/errfmt.go
+++ b/cli/internal/errfmt/errfmt.go
@@ -1,0 +1,133 @@
+package errfmt
+
+import (
+	"fmt"
+	"strings"
+)
+
+type DetailedError struct {
+	Err        error
+	Reason     string
+	Suggestion string
+	Context    map[string]string
+}
+
+func (e *DetailedError) Error() string {
+	var msg strings.Builder
+
+	msg.WriteString(colorize("Error: ", colorRed))
+	msg.WriteString(colorize(e.Err.Error(), colorRed))
+	msg.WriteString("\n")
+
+	if e.Reason != "" {
+		msg.WriteString(colorize("  Reason: ", colorGray))
+		msg.WriteString(e.Reason)
+		msg.WriteString("\n")
+	}
+
+	for key, value := range e.Context {
+		msg.WriteString(fmt.Sprintf("  %s: %s\n", colorize(key, colorGray), value))
+	}
+
+	if e.Suggestion != "" {
+		msg.WriteString(colorize("  Suggestion: ", colorCyan))
+		msg.WriteString(e.Suggestion)
+		msg.WriteString("\n")
+	}
+
+	return msg.String()
+}
+
+func NewDetailedError(err error) *DetailedError {
+	return &DetailedError{Err: err}
+}
+
+func (e *DetailedError) WithReason(reason string) *DetailedError {
+	e.Reason = reason
+	return e
+}
+
+func (e *DetailedError) WithSuggestion(suggestion string) *DetailedError {
+	e.Suggestion = suggestion
+	return e
+}
+
+func (e *DetailedError) WithContext(key, value string) *DetailedError {
+	if e.Context == nil {
+		e.Context = make(map[string]string)
+	}
+	e.Context[key] = value
+	return e
+}
+
+func ConnectionError(url string, err error) error {
+	return NewDetailedError(err).
+		WithReason("Connection refused").
+		WithContext("URL", url).
+		WithSuggestion("Is the API server running?\n               Try: Check if the server is started")
+}
+
+func AuthRequiredError(keyName string) error {
+	return NewDetailedError(fmt.Errorf("authentication required")).
+		WithReason(fmt.Sprintf("Missing API key: %s", keyName)).
+		WithSuggestion(fmt.Sprintf("Set your API key:\n               export %s=your-key-here\n               Or: ely keys create --name my-key", keyName))
+}
+
+func EmblemNotFoundError(name string) error {
+	return NewDetailedError(fmt.Errorf("emblem '%s' not found", name)).
+		WithSuggestion(fmt.Sprintf("Check available emblems:\n               ely search %s\n               Or: ely pull %s", name, name))
+}
+
+func InvalidYAMLError(filePath string, err error) error {
+	return NewDetailedError(err).
+		WithContext("File", filePath).
+		WithSuggestion("Check YAML syntax at https://www.yamllint.com/")
+}
+
+func RateLimitError(retryAfter int) error {
+	return NewDetailedError(fmt.Errorf("rate limit exceeded")).
+		WithReason("Too many requests").
+		WithContext("Retry after", fmt.Sprintf("%d seconds", retryAfter)).
+		WithSuggestion("Wait before retrying or upgrade your plan")
+}
+
+func NetworkError(err error) error {
+	return NewDetailedError(err).
+		WithReason("Network connectivity issue").
+		WithSuggestion("Check your internet connection and try again")
+}
+
+func ConfigNotFoundError() error {
+	return NewDetailedError(fmt.Errorf("configuration not found")).
+		WithReason("No config file exists").
+		WithSuggestion("Run: ely login to authenticate\n               Or create ~/.elysium/config.yaml manually")
+}
+
+func PermissionError(resource string) error {
+	return NewDetailedError(fmt.Errorf("permission denied")).
+		WithReason(fmt.Sprintf("Insufficient permissions for %s", resource)).
+		WithSuggestion("Check your API key permissions or contact support")
+}
+
+func APIError(statusCode int, message string) error {
+	err := fmt.Errorf("API returned status %d: %s", statusCode, message)
+
+	switch statusCode {
+	case 401:
+		return AuthRequiredError("API_KEY")
+	case 403:
+		return PermissionError("this resource")
+	case 404:
+		return NewDetailedError(fmt.Errorf("resource not found")).
+			WithReason(message)
+	case 429:
+		return RateLimitError(60)
+	case 500:
+		return NewDetailedError(err).
+			WithReason("API server error").
+			WithSuggestion("Try again later or contact support")
+	default:
+		return NewDetailedError(err).
+			WithContext("Status", fmt.Sprintf("%d", statusCode))
+	}
+}

--- a/cli/internal/errfmt/errfmt_test.go
+++ b/cli/internal/errfmt/errfmt_test.go
@@ -1,0 +1,221 @@
+package errfmt
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestConnectionError(t *testing.T) {
+	err := ConnectionError("http://localhost:5000", errors.New("dial tcp: connection refused"))
+
+	msg := err.Error()
+	if !strings.Contains(msg, "Connection refused") {
+		t.Error("Should contain reason")
+	}
+	if !strings.Contains(msg, "localhost:5000") {
+		t.Error("Should contain URL")
+	}
+	if !strings.Contains(msg, "Suggestion") {
+		t.Error("Should contain suggestion")
+	}
+}
+
+func TestAuthRequiredError(t *testing.T) {
+	err := AuthRequiredError("CLOTHING_SHOP_API_KEY")
+
+	msg := err.Error()
+	if !strings.Contains(msg, "authentication required") {
+		t.Error("Should contain error message")
+	}
+	if !strings.Contains(msg, "export CLOTHING_SHOP_API_KEY") {
+		t.Error("Should contain export command")
+	}
+	if !strings.Contains(msg, "ely keys create") {
+		t.Error("Should contain keys create command")
+	}
+}
+
+func TestEmblemNotFoundError(t *testing.T) {
+	err := EmblemNotFoundError("my-api")
+
+	msg := err.Error()
+	if !strings.Contains(msg, "my-api") {
+		t.Error("Should contain emblem name")
+	}
+	if !strings.Contains(msg, "not found") {
+		t.Error("Should contain 'not found'")
+	}
+	if !strings.Contains(msg, "ely search") {
+		t.Error("Should contain search suggestion")
+	}
+}
+
+func TestInvalidYAMLError(t *testing.T) {
+	err := InvalidYAMLError("emblem.yaml", errors.New("yaml: line 15: unexpected mapping key"))
+
+	msg := err.Error()
+	if !strings.Contains(msg, "emblem.yaml") {
+		t.Error("Should contain file path")
+	}
+	if !strings.Contains(msg, "line 15") {
+		t.Error("Should contain line number from error")
+	}
+	if !strings.Contains(msg, "yamllint.com") {
+		t.Error("Should contain yamllint URL")
+	}
+}
+
+func TestRateLimitError(t *testing.T) {
+	err := RateLimitError(60)
+
+	msg := err.Error()
+	if !strings.Contains(msg, "rate limit exceeded") {
+		t.Error("Should contain rate limit message")
+	}
+	if !strings.Contains(msg, "60 seconds") {
+		t.Error("Should contain retry after time")
+	}
+	if !strings.Contains(msg, "upgrade your plan") {
+		t.Error("Should contain upgrade suggestion")
+	}
+}
+
+func TestNetworkError(t *testing.T) {
+	err := NetworkError(errors.New("network is unreachable"))
+
+	msg := err.Error()
+	if !strings.Contains(msg, "Network connectivity issue") {
+		t.Error("Should contain network reason")
+	}
+	if !strings.Contains(msg, "internet connection") {
+		t.Error("Should contain internet connection suggestion")
+	}
+}
+
+func TestConfigNotFoundError(t *testing.T) {
+	err := ConfigNotFoundError()
+
+	msg := err.Error()
+	if !strings.Contains(msg, "configuration not found") {
+		t.Error("Should contain config not found message")
+	}
+	if !strings.Contains(msg, "ely login") {
+		t.Error("Should contain login command")
+	}
+	if !strings.Contains(msg, ".elysium/config.yaml") {
+		t.Error("Should contain config path")
+	}
+}
+
+func TestPermissionError(t *testing.T) {
+	err := PermissionError("this resource")
+
+	msg := err.Error()
+	if !strings.Contains(msg, "permission denied") {
+		t.Error("Should contain permission denied message")
+	}
+	if !strings.Contains(msg, "this resource") {
+		t.Error("Should contain resource name")
+	}
+	if !strings.Contains(msg, "API key permissions") {
+		t.Error("Should contain API key suggestion")
+	}
+}
+
+func TestAPIError(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		message    string
+		checks     []string
+	}{
+		{
+			name:       "401 Unauthorized",
+			statusCode: 401,
+			message:    "Unauthorized",
+			checks:     []string{"authentication required", "API_KEY"},
+		},
+		{
+			name:       "403 Forbidden",
+			statusCode: 403,
+			message:    "Forbidden",
+			checks:     []string{"permission denied", "Insufficient permissions"},
+		},
+		{
+			name:       "404 Not Found",
+			statusCode: 404,
+			message:    "Resource not found",
+			checks:     []string{"resource not found", "Resource not found"},
+		},
+		{
+			name:       "429 Rate Limit",
+			statusCode: 429,
+			message:    "Too many requests",
+			checks:     []string{"rate limit exceeded", "60 seconds"},
+		},
+		{
+			name:       "500 Server Error",
+			statusCode: 500,
+			message:    "Internal server error",
+			checks:     []string{"API returned status 500", "server error"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := APIError(tt.statusCode, tt.message)
+			msg := err.Error()
+			for _, check := range tt.checks {
+				if !strings.Contains(msg, check) {
+					t.Errorf("Expected '%s' in error message for %s", check, tt.name)
+				}
+			}
+		})
+	}
+}
+
+func TestDetailedErrorWithContext(t *testing.T) {
+	err := NewDetailedError(errors.New("test error")).
+		WithReason("This is the reason").
+		WithContext("Key", "Value").
+		WithContext("Another", "Entry").
+		WithSuggestion("Try this solution")
+
+	msg := err.Error()
+	if !strings.Contains(msg, "test error") {
+		t.Error("Should contain error message")
+	}
+	if !strings.Contains(msg, "This is the reason") {
+		t.Error("Should contain reason")
+	}
+	if !strings.Contains(msg, "Key") || !strings.Contains(msg, "Value") {
+		t.Error("Should contain first context entry")
+	}
+	if !strings.Contains(msg, "Another") || !strings.Contains(msg, "Entry") {
+		t.Error("Should contain second context entry")
+	}
+	if !strings.Contains(msg, "Try this solution") {
+		t.Error("Should contain suggestion")
+	}
+}
+
+func TestColorDisabled(t *testing.T) {
+	original := colorEnabled
+	t.Run("colors enabled", func(t *testing.T) {
+		colorEnabled = true
+		msg := colorize("test", colorRed)
+		if !strings.Contains(msg, "\033[31m") {
+			t.Error("Should contain ANSI color code when enabled")
+		}
+	})
+
+	t.Run("colors disabled", func(t *testing.T) {
+		colorEnabled = false
+		msg := colorize("test", colorRed)
+		if strings.Contains(msg, "\033[") {
+			t.Error("Should not contain ANSI codes when disabled")
+		}
+	})
+	colorEnabled = original
+}

--- a/cli/internal/executor/runner.go
+++ b/cli/internal/executor/runner.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/elysium/elysium/cli/internal/emblem"
+	"github.com/elysium/elysium/cli/internal/errfmt"
 	"github.com/go-resty/resty/v2"
 )
 
@@ -72,13 +73,30 @@ func (e *Executor) Execute(actionName string, params map[string]interface{}, for
 	}
 
 	if err != nil {
-		return nil, fmt.Errorf("request failed: %w", err)
+		if strings.Contains(err.Error(), "timeout") {
+			return nil, errfmt.NewDetailedError(err).
+				WithReason("Request timed out").
+				WithContext("Timeout", "30s").
+				WithSuggestion("The API is taking too long to respond. Try again or check API status.")
+		}
+		if strings.Contains(err.Error(), "connection refused") || strings.Contains(err.Error(), "connect: connection refused") {
+			return nil, errfmt.ConnectionError(e.definition.BaseURL, err)
+		}
+		return nil, errfmt.NetworkError(err)
 	}
 
 	if resp.IsError() {
 		var errResp map[string]interface{}
 		json.Unmarshal(resp.Body(), &errResp)
-		return nil, fmt.Errorf("API error [%d]: %v", resp.StatusCode(), errResp)
+		errMsg := ""
+		if msg, ok := errResp["error"].(string); ok {
+			errMsg = msg
+		} else if msg, ok := errResp["message"].(string); ok {
+			errMsg = msg
+		} else {
+			errMsg = resp.Status()
+		}
+		return nil, errfmt.APIError(resp.StatusCode(), errMsg)
 	}
 
 	return e.formatOutput(resp.Body(), format)


### PR DESCRIPTION
## Summary
Implements detailed, actionable error messages throughout the CLI.

## Changes
- Added `cli/internal/errfmt/` package for error formatting
- Modified commands to use `DetailedError` with Reason, Context, and Suggestion
- Added ANSI color support (respects NO_COLOR env var)
- Comprehensive test coverage

## Examples

**Before:**
```
Error: failed to connect
```

**After:**
```
Error: connection refused
  Reason: Connection refused
  URL: http://localhost:5000
  Suggestion: Is the API server running?
               Try: Check if the server is started
```

## Testing
- All new tests pass
- Modified existing tests to use new error format

Closes #6