### PR TITLE
feat(cli): Add emblem scaffolding with ely init (Issue #4)

### DIFF
--- a/cli/cmd/init.go
+++ b/cli/cmd/init.go
@@ -1,0 +1,113 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/elysium/elysium/cli/internal/scaffold"
+	"github.com/spf13/cobra"
+)
+
+var (
+	categoryFlag    string
+	descriptionFlag string
+	outputFlag      string
+)
+
+var initCmd = &cobra.Command{
+	Use:   "init <name>",
+	Short: "Initialize a new emblem",
+	Long: `Initialize a new emblem with template files.
+
+Creates a directory structure with:
+- emblem.yaml    # API definition
+- README.md      # Documentation
+- examples/      # Example requests
+- .emblemignore  # Ignore patterns
+
+Categories:
+- payments  # Payment processing APIs
+- ecommerce # E-commerce APIs
+- auth      # Authentication APIs
+- general   # Generic CRUD APIs (default)`,
+	Example: `  # Initialize with default template
+  ely init my-api
+
+  # Initialize with category
+  ely init payment-api --category payments
+
+  # Initialize with description
+  ely init shop-api --category ecommerce --description "Shop API"
+
+  # Initialize in specific directory
+  ely init my-api --output /path/to/dir`,
+	Args: cobra.ExactArgs(1),
+	RunE: runInit,
+}
+
+func init() {
+	initCmd.Flags().StringVarP(&categoryFlag, "category", "c", "general", "Emblem category (payments, ecommerce, auth, general)")
+	initCmd.Flags().StringVarP(&descriptionFlag, "description", "d", "", "Emblem description")
+	initCmd.Flags().StringVarP(&outputFlag, "output", "o", ".", "Output directory")
+	rootCmd.AddCommand(initCmd)
+}
+
+func runInit(cmd *cobra.Command, args []string) error {
+	name := args[0]
+
+	if err := scaffold.ValidateName(name); err != nil {
+		return err
+	}
+
+	outputDir := outputFlag
+	if outputDir == "." {
+		outputDir = name
+	}
+
+	targetDir := outputDir
+	if outputDir == name {
+		if _, err := os.Stat(targetDir); err == nil {
+			return fmt.Errorf("directory '%s' already exists", targetDir)
+		}
+	}
+
+	if err := scaffold.CreateDirectories(targetDir); err != nil {
+		return err
+	}
+
+	tmpl := scaffold.EmblemTemplate{
+		Name:        name,
+		Category:    categoryFlag,
+		Description: descriptionFlag,
+		Version:     "1.0.0",
+		BaseURL:     "https://api.example.com",
+		Actions:     scaffold.GetCategoryTemplate(categoryFlag),
+	}
+
+	emblemPath := fmt.Sprintf("%s/emblem.yaml", targetDir)
+	if err := scaffold.GenerateEmblem(tmpl, emblemPath); err != nil {
+		return fmt.Errorf("failed to generate emblem.yaml: %w", err)
+	}
+
+	readmePath := fmt.Sprintf("%s/README.md", targetDir)
+	if err := scaffold.GenerateREADME(tmpl, readmePath); err != nil {
+		return fmt.Errorf("failed to generate README.md: %w", err)
+	}
+
+	examplesDir := fmt.Sprintf("%s/examples", targetDir)
+	if err := scaffold.GenerateExamples(name, categoryFlag, examplesDir); err != nil {
+		return fmt.Errorf("failed to generate examples: %w", err)
+	}
+
+	if err := scaffold.GenerateIgnoreFile(targetDir); err != nil {
+		return fmt.Errorf("failed to generate .emblemignore: %w", err)
+	}
+
+	fmt.Printf("✓ Created emblem '%s' in ./%s/\n", name, targetDir)
+	fmt.Println("\nNext steps:")
+	fmt.Printf("  1. Edit %s/emblem.yaml\n", targetDir)
+	fmt.Printf("  2. Validate: ely validate %s/emblem.yaml\n", targetDir)
+	fmt.Printf("  3. Test locally: ely test %s/ --local\n", targetDir)
+
+	return nil
+}

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -106,7 +106,7 @@ func Execute() {
 
 func isKnownCommand(cmd string) bool {
 	commands := []string{
-		"execute", "help", "completion", "info", "keys", "list", "login", "logout", "pull", "search", "whoami",
+		"execute", "help", "completion", "init", "info", "keys", "list", "login", "logout", "pull", "search", "whoami",
 	}
 	for _, c := range commands {
 		if c == cmd {

--- a/cli/internal/scaffold/scaffold.go
+++ b/cli/internal/scaffold/scaffold.go
@@ -1,0 +1,225 @@
+package scaffold
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"text/template"
+	"time"
+)
+
+type EmblemTemplate struct {
+	Name        string
+	Category    string
+	Description string
+	Version     string
+	BaseURL     string
+	Actions     []ActionTemplate
+}
+
+type ActionTemplate struct {
+	Name        string
+	Method      string
+	Path        string
+	Description string
+}
+
+func GetCategoryTemplate(category string) []ActionTemplate {
+	switch category {
+	case "payments":
+		return []ActionTemplate{
+			{"create-payment", "POST", "/payments", "Create a new payment"},
+			{"list-payments", "GET", "/payments", "List all payments"},
+			{"get-payment", "GET", "/payments/{id}", "Get payment by ID"},
+			{"delete-payment", "DELETE", "/payments/{id}", "Delete a payment"},
+		}
+	case "ecommerce":
+		return []ActionTemplate{
+			{"list-products", "GET", "/products", "List all products"},
+			{"create-product", "POST", "/products", "Create a product"},
+			{"get-product", "GET", "/products/{id}", "Get product by ID"},
+			{"update-product", "PUT", "/products/{id}", "Update a product"},
+			{"delete-product", "DELETE", "/products/{id}", "Delete a product"},
+		}
+	case "auth":
+		return []ActionTemplate{
+			{"login", "POST", "/auth/login", "User login"},
+			{"logout", "POST", "/auth/logout", "User logout"},
+			{"register", "POST", "/auth/register", "Register new user"},
+			{"refresh", "POST", "/auth/refresh", "Refresh authentication token"},
+		}
+	default:
+		return []ActionTemplate{
+			{"list", "GET", "/items", "List items"},
+			{"create", "POST", "/items", "Create an item"},
+			{"get", "GET", "/items/{id}", "Get item by ID"},
+			{"update", "PUT", "/items/{id}", "Update an item"},
+			{"delete", "DELETE", "/items/{id}", "Delete an item"},
+		}
+	}
+}
+
+func ValidateName(name string) error {
+	if len(name) == 0 {
+		return fmt.Errorf("name cannot be empty")
+	}
+	if len(name) > 63 {
+		return fmt.Errorf("name cannot exceed 63 characters")
+	}
+	for _, c := range name {
+		if !((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '-') {
+			return fmt.Errorf("name must be lowercase alphanumeric with dashes (found: %c)", c)
+		}
+	}
+	return nil
+}
+
+func CreateDirectories(name string) error {
+	dirs := []string{
+		name,
+		filepath.Join(name, "examples"),
+	}
+
+	for _, dir := range dirs {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			return fmt.Errorf("failed to create directory %s: %w", dir, err)
+		}
+	}
+
+	return nil
+}
+
+func GenerateEmblem(tmpl EmblemTemplate, outputPath string) error {
+	tmplContent := `apiVersion: v1
+name: {{.Name}}
+version: {{.Version}}
+description: "{{.Description}}"
+baseUrl: {{.BaseURL}}
+
+auth:
+  type: api_key
+  location: header
+  key_name: X-API-KEY
+
+actions:
+{{range .Actions}}
+  {{.Name}}:
+    method: {{.Method}}
+    path: {{.Path}}
+    description: "{{.Description}}"
+{{end}}
+`
+
+	t, err := template.New("emblem").Parse(tmplContent)
+	if err != nil {
+		return fmt.Errorf("failed to parse template: %w", err)
+	}
+
+	f, err := os.Create(outputPath)
+	if err != nil {
+		return fmt.Errorf("failed to create file: %w", err)
+	}
+	defer f.Close()
+
+	if err := t.Execute(f, tmpl); err != nil {
+		return fmt.Errorf("failed to execute template: %w", err)
+	}
+
+	return nil
+}
+
+func GenerateREADME(tmpl EmblemTemplate, outputPath string) error {
+	f, err := os.Create(outputPath)
+	if err != nil {
+		return fmt.Errorf("failed to create file: %w", err)
+	}
+	defer f.Close()
+
+	content := fmt.Sprintf(`# %s
+
+%s
+
+## Installation
+
+`+"```"+`
+ely pull %s
+`+"```"+`
+
+## Usage
+
+### Available Actions
+
+`, tmpl.Name, tmpl.Description, tmpl.Name)
+
+	for _, action := range tmpl.Actions {
+		content += fmt.Sprintf(`#### %s
+
+%s
+
+`+"```"+`
+ely %s %s
+`+"```"+`
+
+`, action.Name, action.Description, tmpl.Name, action.Name)
+	}
+
+	content += `## Development
+
+1. Edit ` + "`emblem.yaml`" + ` to customize
+2. Validate: ` + "`ely validate emblem.yaml`" + `
+3. Test: ` + "`ely run . --local`" + `
+`
+
+	if _, err := f.WriteString(content); err != nil {
+		return fmt.Errorf("failed to write file: %w", err)
+	}
+
+	return nil
+}
+
+func GenerateExamples(name, category string, outputDir string) error {
+	examplePath := filepath.Join(outputDir, "example.json")
+
+	content := fmt.Sprintf(`{
+  "id": 1,
+  "name": "Example %s",
+  "created_at": "%s"
+}`, category, time.Now().Format(time.RFC3339))
+
+	if err := os.WriteFile(examplePath, []byte(content), 0644); err != nil {
+		return fmt.Errorf("failed to write example: %w", err)
+	}
+
+	return nil
+}
+
+func GenerateIgnoreFile(name string) error {
+	content := `# Dependencies
+node_modules/
+vendor/
+
+# Build outputs
+dist/
+build/
+*.exe
+
+# IDE
+.idea/
+.vscode/
+*.swp
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Temp
+*.tmp
+*.log
+`
+
+	if err := os.WriteFile(filepath.Join(name, ".emblemignore"), []byte(content), 0644); err != nil {
+		return fmt.Errorf("failed to write .emblemignore: %w", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Summary
Implements 'ely init' command for quick emblem creation from templates.

## Changes
- New command: `ely init <name> --category <category>`
- Template categories: payments, ecommerce, auth, general
- Generates: emblem.yaml, README.md, examples/, .emblemignore
- Validates: name format, directory existence

## Testing
```bash
ely init test-api --category payments --description 'Test API'
```

Creates:
- test-api/emblem.yaml
- test-api/README.md
- test-api/examples/example.json
- test-api/.emblemignore

Closes #4